### PR TITLE
Bump dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ type-uuid-derive = { version = "0.1.1", path = "./type-uuid-derive" }
 amethyst = { version = "0.10.0", optional = true }
 
 [dev-dependencies]
-uuid = "0.7.1"
+uuid = { version = "0.8", default-features = false }
 
 [workspace]

--- a/type-uuid-derive/Cargo.toml
+++ b/type-uuid-derive/Cargo.toml
@@ -13,6 +13,6 @@ license = "Apache-2.0 OR MIT"
 proc-macro = true
 
 [dependencies]
-syn = "0.15.23"
-quote = "0.6.10"
-uuid = "0.7.1"
+syn = "1.0"
+quote = "1.0"
+uuid = { version = "0.8", default-features = false }

--- a/type-uuid-derive/src/lib.rs
+++ b/type-uuid-derive/src/lib.rs
@@ -22,7 +22,12 @@ pub fn type_uuid_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStre
             continue;
         };
 
-        if name_value.ident != "uuid" {
+        if name_value
+            .path
+            .get_ident()
+            .map(|i| i != "uuid")
+            .unwrap_or(true)
+        {
             continue;
         }
 


### PR DESCRIPTION
This bumps versions of dependencies, including `syn` and `quote` which would be great to get to 1.0 across the whole ecosystem to reduce compile times.