### PR TITLE
Add autogen feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add `autogen` feature for auto generated name-based UUIDs
+
+[#8]: https://github.com/randomPoison/type-uuid/pull/8
+
 ## [0.1.2] - 2019-12-01
 
 * Sealed the `TypeUuidDynamic` trait so that it can't be implemented downstream. ([#5])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,7 @@ amethyst = { version = "0.10.0", optional = true }
 [dev-dependencies]
 uuid = { version = "0.8", default-features = false }
 
+[features]
+autogen = ["type-uuid-derive/autogen"]
+
 [workspace]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,10 @@
 //! recommend using https://www.uuidgenerator.net, which provides a quick way
 //! generate new UUIDs that you can paste into your code.
 //!
+//! The `autogen` feature can be enabled for automatically generating V5 UUID's based on a
+//! type-uuid namespace (static) and the name of the type being provided. Note, this will cause
+//! UUID conflicts for types with the same name.
+//!
 //! [`TypeUuid`]: ./trait.TypeUuid.html
 
 #[doc(hidden)]

--- a/type-uuid-derive/Cargo.toml
+++ b/type-uuid-derive/Cargo.toml
@@ -16,3 +16,6 @@ proc-macro = true
 syn = "1.0"
 quote = "1.0"
 uuid = { version = "0.8", default-features = false }
+
+[features]
+autogen = ["uuid/v5"]

--- a/type-uuid-derive/src/lib.rs
+++ b/type-uuid-derive/src/lib.rs
@@ -53,7 +53,7 @@ pub fn type_uuid_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStre
 
     #[cfg(feature = "autogen")]
     let uuid =
-        uuid.unwrap_or(uuid::Uuid::new_v5(
+        uuid.unwrap_or_else(|| uuid::Uuid::new_v5(
             &UUID_NAMESPACE,
             name.to_string().as_bytes(),
         ));


### PR DESCRIPTION
This adds a feature-gated `autogen`. This will automatically generate V5 UUID's based on the type name if `TypeUuid` is derived but no static `#[uuid]` is provided.

This comes with the drawback of causing conflicts for types of the same name. I don't think its possible to get the module path of an ident in a procedural macro, otherwise this could be avoided. 

Besides that, however, for normal use cases - this would cut down significantly on boilerplate while having these restrictions:
- The same type name will cause conflicts, even in different module paths
- This is not rename safe

These restrictions is why I have feature gated it, as it is still very useful under many circumstances.